### PR TITLE
Automatic substitution for all php and javascript files

### DIFF
--- a/src/Tasks/Build/Component.php
+++ b/src/Tasks/Build/Component.php
@@ -61,7 +61,7 @@ class Component extends Base implements TaskInterface
 	{
 		$this->say('Building component');
 
-		// Analyize extension structure
+		// Analyze extension structure
 		$this->analyze();
 
 		// Prepare directories

--- a/src/Tasks/Build/Extension.php
+++ b/src/Tasks/Build/Extension.php
@@ -276,6 +276,18 @@ class Extension extends Base implements TaskInterface
 			$this->buildPackage($this->params)->run();
 		}
 
+		// Replacements (date, version etc.) in every php file
+		$dir = new \RecursiveDirectoryIterator($this->getBuildFolder(), \RecursiveDirectoryIterator::SKIP_DOTS);
+		$it = new \RecursiveIteratorIterator($dir);
+
+		foreach ($it as $file)
+		{
+			if (in_array(pathinfo($file, PATHINFO_EXTENSION), array('php', 'js')))
+			{
+				$this->replaceInFile($file);
+			}
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
## DATE##, ##VERSION##, ##YEAR## are now replaced automatically in every php or js file.

Testing instructions:

Test with the PR from @chrisdavenport at weblinks repository:

https://github.com/joomla-extensions/weblinks/pull/243
