### PR TITLE
Added bump version task for replacing the DEPLOY_VERSION placeholder

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -76,4 +76,16 @@ class RoboFile extends \Robo\Tasks
 	{
 		(new \Joomla\Jorobo\Tasks\CopyrightHeader)->run();
 	}
+
+	/**
+	 * Bump Version placeholder __DEPLOY_VERSION__ in this project. (Set the version up in the jorobo.ini)
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0.0
+	 */
+	public function bump()
+	{
+		(new \Joomla\Jorobo\Tasks\BumpVersion())->run();
+	}
 }

--- a/src/Tasks/BumpVersion.php
+++ b/src/Tasks/BumpVersion.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @package     JoRobo
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Jorobo\Tasks;
+
+use Robo\Result;
+use Robo\Task\BaseTask;
+use Robo\Contract\TaskInterface;
+use Robo\Exception\TaskException;
+
+/**
+ * Bump the version of an Joomla extension
+ *
+ * @package  Joomla\Jorobo\Tasks\Component
+ */
+class BumpVersion extends JTask implements TaskInterface
+{
+	use \Robo\Task\Development\loadTasks;
+	use \Robo\Common\TaskIO;
+
+	/**
+	 * Constructor
+	 *
+	 * @since   1.0
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Maps all parts of an extension into a Joomla! installation
+	 *
+	 * @return  bool
+	 *
+	 * @since   1.0
+	 */
+	public function run()
+	{
+		$this->say('Updating ' . $this->getJConfig()->extension . " to " . $this->getJConfig()->version);
+
+		// Reusing the header config here
+		$exclude = explode(",", trim($this->getJConfig()->header->exclude));
+
+		$path = realpath($this->getJConfig()->source);
+		$fileTypes = explode(",", trim($this->getJConfig()->header->files));
+
+		$changedFiles = 0;
+
+		foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path)) as $filename)
+		{
+			if (substr($filename, 0, 1) == '.')
+			{
+				continue;
+			}
+
+			$file = new \SplFileInfo($filename);
+
+			if (!in_array($file->getExtension(), $fileTypes))
+			{
+				continue;
+			}
+
+			// Skip directories in exclude list
+			if (isset($exclude) && count($exclude))
+			{
+				$relative = str_replace(realpath($path), "", $file->getPath());
+
+				// It is possible to have multiple exclude directories
+				foreach ($exclude as $e)
+				{
+					if (stripos($relative, $e) !== false)
+					{
+						$this->say("Excluding " . $filename);
+						continue 2;
+					}
+				}
+			}
+
+			// Load the file
+			$fileContents = file_get_contents($file->getRealPath());
+
+			if (preg_match('#__DEPLOY_VERSION__#', $fileContents))
+			{
+				$fileContents = preg_replace('#__DEPLOY_VERSION__#', $this->getJConfig()->version, $fileContents);
+
+				$this->say('Updating file: ' . $file->getRealPath());
+
+				file_put_contents($file->getRealPath(), $fileContents);
+
+				$changedFiles++;
+			}
+		}
+
+		$this->say('Updated ' . $changedFiles . ' files');
+
+		return true;
+	}
+}

--- a/src/Tasks/JTask.php
+++ b/src/Tasks/JTask.php
@@ -69,11 +69,6 @@ abstract class JTask extends \Robo\Tasks implements TaskInterface
 		$this->loadConfiguration($params);
 		$this->determineOperatingSystem();
 		$this->determineSourceFolder();
-
-		// Registers the application to run Robo commands
-		$runner = new Runner;
-		$app = new Application('Joomla\Jorobo\Tasks\JTask', '1.0.0');
-		$runner->registerCommandClass($app, $this);
 	}
 
 	/**

--- a/src/Tasks/loadTasks.php
+++ b/src/Tasks/loadTasks.php
@@ -65,4 +65,16 @@ trait loadTasks
 	{
 		return new CopyrightHeader($params);
 	}
+
+	/**
+	 * Bump the __DEPLOY_VERSION__ task
+	 *
+	 * @return  BumpVersion
+	 *
+	 * @since   1.0
+	 */
+	protected function taskBumbVersion()
+	{
+		return new BumpVersion();
+	}
 }


### PR DESCRIPTION
Added a new Robo Task for replacing `__DEPLOY_VERSION__` in the extensions source code.

### Testing Instructions

Apply the patch to the weblinks JoRobo version. 

And modify the since tag of an PHP file in the source to:

`@since  __DEPLOY_VERSION__`

After this run:

`vendor/bin/robo bump`

from your cli

Check that `__DEPLOY_VERSION__` has been replaced by the version set in the jorobo.ini (3.6.0-beta currently).

![screenshot 2017-01-14 11 17 23](https://cloud.githubusercontent.com/assets/897638/21954197/0cfc94a4-da4b-11e6-8dbf-237169eea2a8.jpg)


Ping @chrisdavenport here