### PR TITLE
Allow new language files without language tag

### DIFF
--- a/src/Tasks/Build/Language.php
+++ b/src/Tasks/Build/Language.php
@@ -146,12 +146,12 @@ class Language extends Base implements TaskInterface
 	private function analyze()
 	{
 		// Check for all languages here
-		if (empty(glob($this->adminLangPath . "/*/*." . $this->ext . "*.ini")))
+		if (empty(glob($this->adminLangPath . "/*/*" . $this->ext . "*.ini")))
 		{
 			$this->hasAdminLang = false;
 		}
 
-		if (empty(glob($this->frontLangPath . "/*/*." . $this->ext . "*.ini")))
+		if (empty(glob($this->frontLangPath . "/*/*" . $this->ext . "*.ini")))
 		{
 			$this->hasFrontLang = false;
 		}
@@ -238,7 +238,7 @@ class Language extends Base implements TaskInterface
 					while ($file = readdir($fileHdl))
 					{
 						// Only copy language files for this extension (and sys files..)
-						if (substr($file, 0, 1) != '.' && strpos($file, $this->ext . "."))
+						if (substr($file, 0, 1) !== '.' && strpos($file, $this->ext . ".") !== false)
 						{
 							$files[] = array($entry => $file);
 

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -536,7 +536,7 @@ class Package extends Base implements TaskInterface
 
 		// If the package has language files, add those
 		$pkg_languages_path = $pkg_path . "/language";
-		$languages          = glob($pkg_languages_path . "/*/*.pkg_" . $this->getExtensionName() . "*.ini");
+		$languages          = glob($pkg_languages_path . "/*/*pkg_" . $this->getExtensionName() . "*.ini");
 
 		// Add all package language files
 		foreach ($languages as $lang_path)


### PR DESCRIPTION
Since CMS allow and moved to language tag file names in language folders we also allow this for components we build.