### PR TITLE
Fix: symlinking (build and deploy) under Windows works now even if paths contain spaces

### DIFF
--- a/src/Tasks/Build.php
+++ b/src/Tasks/Build.php
@@ -53,7 +53,7 @@ class Build extends JTask
             if (is_dir($this->params['base'] . "\dist\current")) {
                 rmdir($this->params['base'] . "\dist\current");
             }
-            $this->taskExec('mklink /J ' . $this->params['base'] . '\dist\current ' . $this->getWindowsPath($this->getBuildFolder()))
+            $this->taskExec('mklink /J "' . $this->params['base'] . '\dist\current" "' . $this->getWindowsPath($this->getBuildFolder()) . '"')
                 ->run();
         } else {
             if (is_dir($this->params['base'] . "/dist/current")) {

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -97,8 +97,8 @@ class Package extends Base
 
         // Create symlink to current folder
         if ($this->isWindows()) {
-            if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
-                rmdir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
+            if (is_file($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
+                unlink($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
             }
             $this->taskExec('mklink /H"' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
                 ->run();

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -100,7 +100,7 @@ class Package extends Base
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
                 rmdir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
             }
-            $this->taskExec('mklink /J ' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . ' ' . $this->getWindowsPath($this->target))
+            $this->taskExec('mklink /J "' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
                 ->run();
         } else {
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -100,7 +100,7 @@ class Package extends Base
             if (is_file($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
                 unlink($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
             }
-            $this->taskExec('mklink /H"' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
+            $this->taskExec('mklink /H "' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
                 ->run();
         } else {
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -100,7 +100,7 @@ class Package extends Base
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
                 rmdir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
             }
-            $this->taskExec('mklink "' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
+            $this->taskExec('mklink /H"' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
                 ->run();
         } else {
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {

--- a/src/Tasks/Deploy/Package.php
+++ b/src/Tasks/Deploy/Package.php
@@ -100,7 +100,7 @@ class Package extends Base
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {
                 rmdir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip");
             }
-            $this->taskExec('mklink /J "' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
+            $this->taskExec('mklink "' . $this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip" . '" "' . $this->getWindowsPath($this->target) . '"')
                 ->run();
         } else {
             if (is_dir($this->params['base'] . "\dist\pkg-" . $this->getExtensionName() . "-current.zip")) {


### PR DESCRIPTION
I added escape quotes for the paths, so creating symlinks works event if paths contain spaces.
Fixed symlink for package zip files (windows)