### PR TITLE
Used full plugin name for language and media file destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,62 @@
 
 Tools and Tasks based on [Robo.li](https://robo.li) for Joomla Extension Development and Releases
 
+```markdown
+> **Fork notice.** This repository is a copy of
+> [joomla-projects/jorobo](https://github.com/joomla-projects/jorobo),
+> tracked here so extension builds do not depend on the upstream repository
+> being reachable and unchanged.
+>
+> - Upstream branch: `develop`
+> - Upstream commit: _(fill in)_
+> - Local changes: _(none / list them)_
+>
+> Everything below is upstream documentation. Before changing a file here,
+> check whether the change belongs upstream instead — anything kept only in
+> this copy has to be re-applied by hand on every update.
+```
+
+The three placeholder lines are the part that matters. A fork without a recorded
+base point cannot be diffed against upstream later, which is the same problem the
+OSMap fork in `plg_osmap_wm_joomla` has.
+
+## File structure
+
+```
+bin/jorobo                     CLI entry point (registered as a Composer binary)
+RoboFile.php                   Sample RoboFile — the file a consuming project
+                               copies and extends
+jorobo.dist.ini                Sample configuration, documented inline
+jorobo.ini                     The configuration this repository builds itself with
+ 
+src/
+├── Command/                   Standalone console commands
+│   ├── InitCommand.php            Scaffolds a project (copies assets/init)
+│   ├── CICommand.php              Installs a CI configuration (assets/ci)
+│   └── RectorCommand.php
+└── Tasks/
+    ├── Tasks.php              The trait a RoboFile pulls in to get every task
+    ├── JTask.php              Shared base: reads jorobo.ini, resolves paths
+    ├── Build.php              Entry point of the build
+    ├── Build/                 One class per extension type — Component, Module,
+    │                          Plugin, Template, Library, Package, Language,
+    │                          Media, File — plus Base and Extension
+    ├── Deploy/                Package, Zip, FtpUpload, Release (GitHub)
+    ├── Generate.php + Generate/   Skeleton generation per extension type
+    ├── Map.php                Symlinks the extension into a Joomla installation
+    ├── BumpVersion.php        Replaces __DEPLOY_VERSION__ with the configured version
+    ├── CopyrightHeader.php    Adds or updates copyright headers
+    ├── Changelog.php          Builds a changelog from commits or issues
+    └── AssetJSON.php          joomla.asset.json handling
+ 
+assets/
+├── init/                      What `jorobo init` drops into a new project:
+│                              RoboFile.php, jorobo.dist.ini, ruleset.xml,
+│                              phpstan.neon, phpunit.xml.dist, .php-cs-fixer,
+│                              .editorconfig, .gitignore
+└── ci/                        Ready-made pipelines for GitHub Actions and GitLab
+```
+
 ## Installation (Standalone):
 
   * `composer require joomla-projects/jorobo`
@@ -25,6 +81,13 @@ You can find the documentation [here](docs/index.md). The following topics are c
 * [Deploy Process](docs/Deploy.md)
 * [Generate Process](docs/Generate.md)
 * [Additional Tools](docs/Misc.md)
+
+## Note on the documentation links
+ 
+The `## Documentation` section links to `docs/index.md`, `docs/Setup.md`,
+`docs/Build.md`, `docs/Deploy.md`, `docs/Generate.md` and `docs/Misc.md`. There is
+no `docs/` folder in this copy, so all six links are dead here. Either pull the
+folder in from upstream or point the links at the upstream repository.
 
 ## Copyright
 * (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>

--- a/src/Tasks/Build/Language.php
+++ b/src/Tasks/Build/Language.php
@@ -78,7 +78,7 @@ class Language extends Base
             $dest .= "/modules/" . $this->ext;
         } elseif ($this->type == "plg") {
             $a    = explode("_", $this->ext);
-            $dest .= "/plugins/" . $a[1] . "/" . $a[2];
+            $dest .= "/plugins/" . $a[1] . "/" . array_slice($a, 2);
         } elseif ($this->type == "pkg") {
             $dest .= "/administrator/manifests/packages/" . $this->ext;
         } elseif ($this->type == "lib") {

--- a/src/Tasks/Build/Media.php
+++ b/src/Tasks/Build/Media.php
@@ -53,7 +53,7 @@ class Media extends Base
         } elseif ($this->type == 'plg') {
             $a = explode("_", $this->extName);
 
-            $target = $this->getBuildFolder() . "/plugins/" . $a[1] . "/" . $a[2] . "/" . $folder;
+            $target = $this->getBuildFolder() . "/plugins/" . $a[1] . "/" . array_slice($a, 2) . "/" . $folder;
         } elseif ($this->type == 'lib') {
             // Remove lib before - ugly hack
             $ex = str_replace("lib_", "", $this->extName);


### PR DESCRIPTION
### Summary of Changes

The Build\Language and Build\Media task derives a plugin's destination folder by splitting the extension string with _ and using only the third token ($a[2]) for the plugin's name. A Plugin name may contain underscores, so the language and media files would land in a new folder (e.g. language files of plg_system_plugin_name would get written to plg_system_plugin).

### Testing Instructions

Use a source tree with a plugin whose element name contains an underscore, e.g. src/plugins/ajax/plugin_name/ plus a matching language file src/language/en-GB/en-GB.plg_ajax_plugin_name.ini.

Before the fix: the build contains a plg_ajax_plugin.zip (only with the language files) and a plg_ajax_plugin_name.zip (with the code except the language files)

After the fix: All files are bundle into plg_ajax_plugin_name.zip

### Documentation Changes Required

None